### PR TITLE
FIX: Code fences exception when not providing language

### DIFF
--- a/src/app/(private)/(docs)/docs/drift/linux/users/page.md
+++ b/src/app/(private)/(docs)/docs/drift/linux/users/page.md
@@ -94,7 +94,7 @@ If you want to use public-key authenitcation, then you will need to add an addit
 
 Overall the custom_user.conf could look something like this:
 
-```vim
+```
 AllowUsers user1 user2 user3
 
 Match User user1,user2,

--- a/src/app/(private)/(docs)/docs/lepton/external_api/feide/page.md
+++ b/src/app/(private)/(docs)/docs/lepton/external_api/feide/page.md
@@ -35,7 +35,7 @@ Dette vil redirecte brukeren til Feide sin egen innloggingsside som du mest sann
 
 Etter at bruker har logget inn med riktig Feide brukernavn og passord, blir brukeren sendt tilbake til vår redirect_url:
 
-```vim
+```
 HTTP/1.1 302 Found
 Location: https://tihlde.org/ny-bruker/feide?
 code=0f8cf5fa-dc3f-4c9d-a60c-b6016c4134fa&

--- a/src/markdoc/nodes.js
+++ b/src/markdoc/nodes.js
@@ -57,6 +57,7 @@ const nodes = {
     attributes: {
       language: {
         type: String,
+        default: '',
       },
     },
   },


### PR DESCRIPTION
- **Added default value for code fence language**
- **Remove "vim" codefences from code blocks that do not need syntax highlighting**
