### PR TITLE
Fix image tag in OpenStack installation page

### DIFF
--- a/src/app/(private)/(docs)/docs/drift/openstack/installation/page.md
+++ b/src/app/(private)/(docs)/docs/drift/openstack/installation/page.md
@@ -11,7 +11,7 @@ Det varierer fra person til person hva man foretrekker å bruke. Men merk at hvi
 ### Enkel oversikt
 Her er en enkel oversikt over serverne som vi har i dag, hva de inneholder, og hvordan nettverkstrafikken går gjennom de:
 
-![OpenstackOverview](/public/images/OpenStackOverviewDark.png)
+<img src="images/OpenStackOverviewDark.png" alt="OpenstackOverview" />
 
 ## CLI
 


### PR DESCRIPTION
Updated image syntax in installation documentation.

"Application error: a server-side exception has occurred (see the server logs for more information).
Digest: 88199924"

"
3996-c05f733867857eac.js:1 Error: An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.
window.console.error	@	3996-c05f733867857eac.js:1
"

Kan være fordi bildet peket til public mappen?? Endret dette nå, kanskje det fungerer